### PR TITLE
Remove hardcoded `XDG_DATA_DIR`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ dirs = "3"
 gettext-rs = { version = "0.7", features = ["gettext-system"]}
 memchr = "2"
 thiserror = "1"
+xdg = "2.4.0"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -3,10 +3,11 @@
 
 use std::fs;
 
-use freedesktop_desktop_entry::{default_paths, DesktopEntry, Iter};
+use freedesktop_desktop_entry::{default_paths, DesktopEntry, Iter, PathSource};
 
 fn main() {
-    for (path_src, path) in Iter::new(default_paths()) {
+    for path in Iter::new(default_paths()) {
+        let path_src = PathSource::guess_from(&path);
         if let Ok(bytes) = fs::read_to_string(&path) {
             if let Ok(entry) = DesktopEntry::decode(&path, &bytes) {
                 println!("{:?}: {}\n---\n{}", path_src, path.display(), entry);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl PathSource {
     /// Attempts to determine the PathSource for a given Path.
     /// Note that this is a best-effort guesting function, and its results should be treated as
     /// such (e.g.: non-canonical).
-    fn guess_from(path: &Path) -> PathSource {
+    pub fn guess_from(path: &Path) -> PathSource {
         let base_dirs = BaseDirectories::new().unwrap();
         let data_home = base_dirs.get_data_home();
 


### PR DESCRIPTION
Remove hardcoded directory paths, and use the read the applicable
environment variables. This avoids ignoring locally configured paths,
and also avoid picking up paths explicitly removed by the user.

The `PathSource` value is now a best-effort guess, since it's possible
that paths don't match any expected values (e.g.: users can add anything
like `/opt/my-toolkit/`.

Note that, while `xdg` is a new direct dependency, it was already a
transitive dependency, so there's no no dependencies here.

The potential panic (due to `unwrap()`) can happen under the exact same
scenario: when failing to determine the home path. This should ideally
be fixed, but is slightly out of scope.

I have to point out that I'm not convinced that `PathSource` is a great
idea; especially since we're mostly trying to guess them. Probably
inspecting the desktop entry files would be a better idea. Flatpak
applications in particular, include a `X-Flatpak` key to recognise them.
I'm unusure about nix entries. However, removing `PathSource` would be a
larger breaking change, so I'd rather discuss that separately.

Fixes #2