### PR TITLE
XDG_DATA_HOME should surpass XDG_DATA_DIRS in priority

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,8 +327,9 @@ impl PathSource {
 /// Panics in case determining the current home directory fails.
 pub fn default_paths() -> Vec<PathBuf> {
     let base_dirs = BaseDirectories::new().unwrap();
-    let mut data_dirs = base_dirs.get_data_dirs();
+    let mut data_dirs: Vec<PathBuf> = vec![];
     data_dirs.push(base_dirs.get_data_home());
+    data_dirs.append(&mut base_dirs.get_data_dirs());
 
     data_dirs.iter().map(|d| d.join("applications")).collect()
 }


### PR DESCRIPTION
According to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html), the XDG_DATA_HOME environment variable should be prioritized over the XDG_DATA_DIRS environment variable when reading `.desktop` entries.

This is specified in the "Environment Variables" section of the specification as follows:
> The order of base directories denotes their importance; the first directory listed is the most important. When the same information is defined in multiple places the information defined relative to the more important base directory takes precedent. The base directory defined by $XDG_DATA_HOME is considered more important than any of the base directories defined by $XDG_DATA_DIRS. The base directory defined by $XDG_CONFIG_HOME is considered more important than any of the base directories defined by $XDG_CONFIG_DIRS.
