### PR TITLE
feat: add path guesses for desktop entry daemon entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,9 @@ pub enum PathSource {
     SystemLocal,
     SystemFlatpak,
     SystemSnap,
+    SessionTemporary,
+    ProcessTemporary,
+    DesktopEntryDaemon,
     Other(String),
 }
 
@@ -315,6 +318,18 @@ impl PathSource {
             || path.to_string_lossy().contains(".nix")
         {
             PathSource::LocalNix
+        } else if path
+            .to_string_lossy()
+            .contains("/desktop-entry-daemon/process/")
+        {
+            PathSource::ProcessTemporary
+        } else if path
+            .to_string_lossy()
+            .contains("/desktop-entry-daemon/session/")
+        {
+            PathSource::SessionTemporary
+        } else if path.to_string_lossy().contains("/desktop-entry-daemon/") {
+            PathSource::DesktopEntryDaemon
         } else {
             PathSource::Other(String::from("unknown"))
         }


### PR DESCRIPTION
[Desktop Entry Daemon](https://github.com/ryanabx/desktop-entry-daemon) is a daemon that allows you to register desktop entries and icons at runtime.

There are 3 lifetimes a client can choose to use:
* Process - Desktop entries and icons will be cleared when the calling process exits
* Session - Desktop entries and icons will be cleared when the session is restarted OR when the daemon restarts
* Persistent - Desktop entries and icons are persistent across reboots and won't be deleted unless explicitly called to do so.

The directories for these lifetimes are:
* Process - `/run/user/$UID/desktop-entry-daemon/process/`
* Session - `/run/user/$UID/desktop-entry-daemon/session/`
* Persistent - `$HOME/.cache/desktop-entry-daemon/`

This PR allows for the `PathSource::guess_from()` function to identify paths from desktop-entry-daemon.