### PR TITLE
fix (regression): re-export DecodeError (previously supported in v0.5.2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod decoder;
 mod iter;
 
 pub mod matching;
+pub use decoder::DecodeError;
 
 pub use self::iter::Iter;
 use std::borrow::Cow;


### PR DESCRIPTION
Whilst upgrading from version `v0.5.2` to `v0.6.2`, I ran into some issues with `thiserror` when trying to support errors from this library since the actual error-type was no longer exported [like it was previously](https://docs.rs/freedesktop-desktop-entry/0.5.2/freedesktop_desktop_entry/enum.DecodeError.html).

```rust
#[derive(Debug, Error)]
pub enum ThemeError {
    #[error("Failed to Read Index")]
    FileError(#[from] std::io::Error),
    #[error("Failed to Parse Index")]
    // would like to use this here below again pls :)
    IndexError(#[from] freedesktop_desktop_entry::DecodeError),
    #[error("No Such Group")]
    NoSuchGroup(&'static str),
    #[error("No Such Key")]
    NoSuchKey(&'static str),
    #[error("Unselected Theme")]
    UnselectedTheme,
    #[error("Invalid Path Name")]
    BadPathName(PathBuf),
}
```

I assume this change was simply overlooked, but would very much like it back since its very convenient for me lol.
Thanks :)