### PR TITLE
Revert the drop of matching. Only remove the necessary functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ categories = [ "os::unix-apis" ]
 keywords = [ "freedesktop", "desktop", "entry" ]
 
 [dependencies]
+dirs = "5.0.1"
 gettext-rs = { version = "0.7", features = ["gettext-system"]}
 memchr = "2"
+textdistance = "1.0.2"
+strsim = "0.11.1"
 thiserror = "1"
 xdg = "2.4.0"
+log = "0.4.21"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -71,7 +71,10 @@ impl<'a> DesktopEntry<'a> {
     }
 
     /// Return an owned [`DesktopEntry`]
-    pub fn from_path<L>(path: PathBuf, locales_filter: Option<&[L]>) -> Result<DesktopEntry<'static>, DecodeError>
+    pub fn from_path<L>(
+        path: PathBuf,
+        locales_filter: Option<&[L]>,
+    ) -> Result<DesktopEntry<'static>, DecodeError>
     where
         L: AsRef<str>,
     {
@@ -125,7 +128,11 @@ fn process_line<'buf, 'local_ref, 'res: 'local_ref + 'buf, F, L>(
                 let locale = &key[start + 1..key.len() - 1];
 
                 match locales_filter {
-                    Some(locales_filter) if !locales_filter.iter().any(|l| l.as_ref() == locale) => return,
+                    Some(locales_filter)
+                        if !locales_filter.iter().any(|l| l.as_ref() == locale) =>
+                    {
+                        return
+                    }
                     _ => (),
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,8 +476,11 @@ fn add_field() {
 fn env_with_locale() {
     let locales = &["fr_FR"];
 
-    let de = DesktopEntry::from_path(PathBuf::from("tests/org.mozilla.firefox.desktop"), Some(locales))
-        .unwrap();
+    let de = DesktopEntry::from_path(
+        PathBuf::from("tests/org.mozilla.firefox.desktop"),
+        Some(locales),
+    )
+    .unwrap();
 
     assert_eq!(de.generic_name(locales).unwrap(), "Navigateur Web");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 mod decoder;
 mod iter;
 
+pub mod matching;
 pub use decoder::DecodeError;
 
 pub use self::iter::Iter;
@@ -475,11 +476,8 @@ fn add_field() {
 fn env_with_locale() {
     let locales = &["fr_FR"];
 
-    let de = DesktopEntry::from_path(
-        PathBuf::from("tests/org.mozilla.firefox.desktop"),
-        Some(locales),
-    )
-    .unwrap();
+    let de = DesktopEntry::from_path(PathBuf::from("tests/org.mozilla.firefox.desktop"), Some(locales))
+        .unwrap();
 
     assert_eq!(de.generic_name(locales).unwrap(), "Navigateur Web");
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -99,21 +99,26 @@ impl<'a> DesktopEntry<'a> {
             .max_by(|e1, e2| e1.total_cmp(e2))
             .unwrap_or(0.0)
     }
+}
 
-    /// Return true if the appid provided match this [`DesktopEntry`].
-    pub fn try_match_appid(&'a self, appid: &str) -> bool {
-        let normalized_appid = appid.to_lowercase();
+/// Return the corresponding [`DesktopEntry`] that match the given appid.
+pub fn find_entry_from_appid<'a, I>(entries: I, appid: &str) -> Option<&'a DesktopEntry<'a>>
+where
+    I: Iterator<Item = &'a DesktopEntry<'a>>,
+{
+    let normalized_appid = appid.to_lowercase();
 
-        if self.appid.to_lowercase() == normalized_appid {
+    entries.into_iter().find(|e| {
+        if e.appid.to_lowercase() == normalized_appid {
             return true;
         }
 
-        if let Some(field) = self.startup_wm_class() {
+        if let Some(field) = e.startup_wm_class() {
             if field.to_lowercase() == normalized_appid {
                 return true;
             }
         }
 
         false
-    }
+    })
 }

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::DesktopEntry;
-use log::debug;
-use std::cmp::max;
 
 impl<'a> DesktopEntry<'a> {
     /// The returned value is between 0.0 and 1.0 (higher value means more similar).
@@ -101,162 +99,21 @@ impl<'a> DesktopEntry<'a> {
             .max_by(|e1, e2| e1.total_cmp(e2))
             .unwrap_or(0.0)
     }
-}
-fn compare_str<'a>(pattern: &'a str, de_value: &'a str) -> f64 {
-    let lcsstr = textdistance::str::lcsstr(pattern, de_value);
 
-    lcsstr as f64 / (max(pattern.len(), de_value.len())) as f64
-}
+    /// Return true if the appid provided match this [`DesktopEntry`].
+    pub fn try_match_appid(&'a self, appid: &str) -> bool {
+        let normalized_appid = appid.to_lowercase();
 
-/// From 0 to 1.
-/// 1 is a perfect match.
-fn match_entry_from_id(pattern: &str, de: &DesktopEntry) -> f64 {
-    // (pattern, malus)
-    let mut de_inputs = Vec::with_capacity(4);
-
-    let id = de.appid.to_lowercase();
-
-    if let Some(last_part_of_id) = id.split('.').last() {
-        de_inputs.push((last_part_of_id.to_owned(), 0.06));
-    }
-
-    de_inputs.push((id, 0.));
-
-    if let Some(i) = de.startup_wm_class() {
-        de_inputs.push((i.to_lowercase(), 0.));
-    }
-
-    if let Some(i) = de.exec() {
-        de_inputs.push((i.to_lowercase(), 0.06));
-    }
-
-    de_inputs
-        .iter()
-        .map(|de| (compare_str(pattern, &de.0) - de.1).max(0.))
-        .max_by(|e1, e2| e1.total_cmp(e2))
-        .unwrap_or(0.0)
-}
-
-#[derive(Debug, Clone)]
-pub struct MatchAppIdOptions {
-    /// Minimal score required to validate a match.
-    /// Must be between 0 and 1
-    pub min_score: f64,
-    /// Optional field to lower the minimal score required to match
-    /// if the entropy is at a certain value, e.i if the two best matches
-    /// hare very different.
-    /// - First element - minimal entropy, between 0 and 1
-    /// - Second element - minimal score, between 0 and 1
-    pub entropy: Option<(f64, f64)>,
-}
-
-impl Default for MatchAppIdOptions {
-    fn default() -> Self {
-        Self {
-            min_score: 0.15,
-            entropy: Some((0.15, 0.1)),
+        if self.appid.to_lowercase() == normalized_appid {
+            return true;
         }
-    }
-}
 
-/// Return the best match over all provided [`DesktopEntry`].
-/// Use this to match over the values provided by the compositor, not the user.
-/// First entries get the priority.
-pub fn get_best_match<'a, I>(
-    patterns: &[I],
-    entries: &'a [DesktopEntry<'a>],
-    options: MatchAppIdOptions,
-) -> Option<&'a DesktopEntry<'a>>
-where
-    I: AsRef<str>,
-{
-    let mut max_score = None;
-    let mut second_max_score = 0.;
-
-    let normalized_patterns = patterns
-        .iter()
-        .map(|e| e.as_ref().to_lowercase())
-        .inspect(|e| {
-            debug!("searching with {}", e);
-        })
-        .collect::<Vec<_>>();
-
-    for de in entries {
-        let score = normalized_patterns
-            .iter()
-            .map(|p| match_entry_from_id(p, de))
-            .max_by(|e1, e2| e1.total_cmp(e2))
-            .unwrap_or(0.0);
-
-        match max_score {
-            Some((prev_max_score, _)) => {
-                if prev_max_score < score {
-                    debug!(
-                        "found {} for {}. Score: {}",
-                        de.appid,
-                        patterns[0].as_ref(),
-                        score
-                    );
-                    second_max_score = prev_max_score;
-                    max_score = Some((score, de));
-                }
-            }
-            None => {
-                debug!(
-                    "found: {} for {}. Score: {}",
-                    de.appid,
-                    patterns[0].as_ref(),
-                    score
-                );
-                max_score = Some((score, de));
+        if let Some(field) = self.startup_wm_class() {
+            if field.to_lowercase() == normalized_appid {
+                return true;
             }
         }
 
-        if score > 0.99 {
-            break;
-        }
-    }
-
-    if let Some((max_score, de)) = max_score {
-        if max_score > options.min_score {
-            Some(de)
-        } else if let Some((min_entropy, min_score_entropy)) = options.entropy {
-            let entropy = max_score - second_max_score;
-
-            if entropy > min_entropy && max_score > min_score_entropy {
-                Some(de)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::{default_paths, get_languages_from_env, matching::compare_str, DesktopEntry, Iter};
-
-    use super::{get_best_match, MatchAppIdOptions};
-
-    #[test]
-    fn find_de() {
-        let entries =
-            DesktopEntry::from_paths(Iter::new(default_paths()), Some(&get_languages_from_env()))
-                .filter_map(|e| e.ok())
-                .collect::<Vec<_>>();
-
-        let e = get_best_match(&["gnome-disks"], &entries, MatchAppIdOptions::default());
-
-        println!("found {}", e.unwrap().appid);
-    }
-    #[test]
-    fn a() {
-        let res = compare_str("org.gnome.tweaks", "gnome.disks");
-
-        println!("{res}")
+        false
     }
 }

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -1,104 +1,107 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::DesktopEntry;
+use log::debug;
 use std::cmp::max;
 
-use log::debug;
-
-use crate::DesktopEntry;
-
-/// The returned value is between 0.0 and 1.0 (higher value means more similar).
-/// You can use the `additional_values` parameter to add runtime string.
-pub fn get_entry_score<'a, Q, L>(
-    query: Q,
-    entry: &'a DesktopEntry<'a>,
-    locales: &[L],
-    additional_values: &'a [&'a str],
-) -> f64
-where
-    Q: AsRef<str>,
-    L: AsRef<str>,
-{
-    #[inline]
-    fn add_value(v: &mut Vec<String>, value: &str, is_multiple: bool) {
-        if is_multiple {
-            value.split(';').for_each(|e| v.push(e.to_lowercase()));
-        } else {
-            v.push(value.to_lowercase());
+impl<'a> DesktopEntry<'a> {
+    /// The returned value is between 0.0 and 1.0 (higher value means more similar).
+    /// You can use the `additional_haystack_values` parameter to add relevant string that are not part of the desktop entry.
+    pub fn match_query<Q, L>(
+        &'a self,
+        query: Q,
+        locales: &'a [L],
+        additional_haystack_values: &'a [&'a str],
+    ) -> f64
+    where
+        Q: AsRef<str>,
+        L: AsRef<str>,
+    {
+        #[inline]
+        fn add_value(v: &mut Vec<String>, value: &str, is_multiple: bool) {
+            if is_multiple {
+                value.split(';').for_each(|e| v.push(e.to_lowercase()));
+            } else {
+                v.push(value.to_lowercase());
+            }
         }
-    }
 
-    // (field name, is separated by ";")
-    let fields = [
-        ("Name", false),
-        ("GenericName", false),
-        ("Comment", false),
-        ("Categories", true),
-        ("Keywords", true),
-    ];
+        // (field name, is separated by ";")
+        let fields = [
+            ("Name", false),
+            ("GenericName", false),
+            ("Comment", false),
+            ("Categories", true),
+            ("Keywords", true),
+        ];
 
-    let mut normalized_values: Vec<String> = Vec::new();
+        let mut normalized_values: Vec<String> = Vec::new();
 
-    normalized_values.extend(additional_values.iter().map(|val| val.to_lowercase()));
+        normalized_values.extend(
+            additional_haystack_values
+                .iter()
+                .map(|val| val.to_lowercase()),
+        );
 
-    let desktop_entry_group = entry.groups.get("Desktop Entry");
+        let desktop_entry_group = self.groups.get("Desktop Entry");
 
-    for field in fields {
-        if let Some(group) = desktop_entry_group {
-            if let Some((default_value, locale_map)) = group.get(field.0) {
-                add_value(&mut normalized_values, default_value, field.1);
+        for field in fields {
+            if let Some(group) = desktop_entry_group {
+                if let Some((default_value, locale_map)) = group.get(field.0) {
+                    add_value(&mut normalized_values, default_value, field.1);
 
-                let mut at_least_one_locale = false;
+                    let mut at_least_one_locale = false;
 
-                for locale in locales {
-                    match locale_map.get(locale.as_ref()) {
-                        Some(value) => {
-                            add_value(&mut normalized_values, value, field.1);
-                            at_least_one_locale = true;
-                        }
-                        None => {
-                            if let Some(pos) = locale.as_ref().find('_') {
-                                if let Some(value) = locale_map.get(&locale.as_ref()[..pos]) {
-                                    add_value(&mut normalized_values, value, field.1);
-                                    at_least_one_locale = true;
+                    for locale in locales {
+                        match locale_map.get(locale.as_ref()) {
+                            Some(value) => {
+                                add_value(&mut normalized_values, value, field.1);
+                                at_least_one_locale = true;
+                            }
+                            None => {
+                                if let Some(pos) = locale.as_ref().find('_') {
+                                    if let Some(value) = locale_map.get(&locale.as_ref()[..pos]) {
+                                        add_value(&mut normalized_values, value, field.1);
+                                        at_least_one_locale = true;
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                if !at_least_one_locale {
-                    if let Some(domain) = &entry.ubuntu_gettext_domain {
-                        let gettext_value = crate::dgettext(domain, default_value);
-                        if !gettext_value.is_empty() {
-                            add_value(&mut normalized_values, &gettext_value, false);
+                    if !at_least_one_locale {
+                        if let Some(domain) = &self.ubuntu_gettext_domain {
+                            let gettext_value = crate::dgettext(domain, default_value);
+                            if !gettext_value.is_empty() {
+                                add_value(&mut normalized_values, &gettext_value, false);
+                            }
                         }
                     }
                 }
             }
         }
+
+        let query = query.as_ref().to_lowercase();
+
+        let query_espaced = query.split_ascii_whitespace().collect::<Vec<_>>();
+
+        normalized_values
+            .into_iter()
+            .map(|de_field| {
+                let jaro_score = strsim::jaro_winkler(&query, &de_field);
+
+                if query_espaced.iter().any(|query| de_field.contains(*query)) {
+                    // provide a bonus if the query is contained in the de field
+                    (jaro_score + 0.1).clamp(0.61, 1.)
+                } else {
+                    jaro_score
+                }
+            })
+            .max_by(|e1, e2| e1.total_cmp(e2))
+            .unwrap_or(0.0)
     }
-
-    let query = query.as_ref().to_lowercase();
-
-    let query_espaced = query.split_ascii_whitespace().collect::<Vec<_>>();
-
-    normalized_values
-        .into_iter()
-        .map(|de_field| {
-            let jaro_score = strsim::jaro_winkler(&query, &de_field);
-
-            if query_espaced.iter().any(|query| de_field.contains(*query)) {
-                // provide a bonus if the query is contained in the de field
-                (jaro_score + 0.1).clamp(0.61, 1.)
-            } else {
-                jaro_score
-            }
-        })
-        .max_by(|e1, e2| e1.total_cmp(e2))
-        .unwrap_or(0.0)
 }
-
 fn compare_str<'a>(pattern: &'a str, de_value: &'a str) -> f64 {
     let lcsstr = textdistance::str::lcsstr(pattern, de_value);
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -1,0 +1,259 @@
+// Copyright 2021 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use std::cmp::max;
+
+use log::debug;
+
+use crate::DesktopEntry;
+
+/// The returned value is between 0.0 and 1.0 (higher value means more similar).
+/// You can use the `additional_values` parameter to add runtime string.
+pub fn get_entry_score<'a, Q, L>(
+    query: Q,
+    entry: &'a DesktopEntry<'a>,
+    locales: &[L],
+    additional_values: &'a [&'a str],
+) -> f64
+where
+    Q: AsRef<str>,
+    L: AsRef<str>,
+{
+    #[inline]
+    fn add_value(v: &mut Vec<String>, value: &str, is_multiple: bool) {
+        if is_multiple {
+            value.split(';').for_each(|e| v.push(e.to_lowercase()));
+        } else {
+            v.push(value.to_lowercase());
+        }
+    }
+
+    // (field name, is separated by ";")
+    let fields = [
+        ("Name", false),
+        ("GenericName", false),
+        ("Comment", false),
+        ("Categories", true),
+        ("Keywords", true),
+    ];
+
+    let mut normalized_values: Vec<String> = Vec::new();
+
+    normalized_values.extend(additional_values.iter().map(|val| val.to_lowercase()));
+
+    let desktop_entry_group = entry.groups.get("Desktop Entry");
+
+    for field in fields {
+        if let Some(group) = desktop_entry_group {
+            if let Some((default_value, locale_map)) = group.get(field.0) {
+                add_value(&mut normalized_values, default_value, field.1);
+
+                let mut at_least_one_locale = false;
+
+                for locale in locales {
+                    match locale_map.get(locale.as_ref()) {
+                        Some(value) => {
+                            add_value(&mut normalized_values, value, field.1);
+                            at_least_one_locale = true;
+                        }
+                        None => {
+                            if let Some(pos) = locale.as_ref().find('_') {
+                                if let Some(value) = locale_map.get(&locale.as_ref()[..pos]) {
+                                    add_value(&mut normalized_values, value, field.1);
+                                    at_least_one_locale = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !at_least_one_locale {
+                    if let Some(domain) = &entry.ubuntu_gettext_domain {
+                        let gettext_value = crate::dgettext(domain, default_value);
+                        if !gettext_value.is_empty() {
+                            add_value(&mut normalized_values, &gettext_value, false);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let query = query.as_ref().to_lowercase();
+
+    let query_espaced = query.split_ascii_whitespace().collect::<Vec<_>>();
+
+    normalized_values
+        .into_iter()
+        .map(|de_field| {
+            let jaro_score = strsim::jaro_winkler(&query, &de_field);
+
+            if query_espaced.iter().any(|query| de_field.contains(*query)) {
+                // provide a bonus if the query is contained in the de field
+                (jaro_score + 0.1).clamp(0.61, 1.)
+            } else {
+                jaro_score
+            }
+        })
+        .max_by(|e1, e2| e1.total_cmp(e2))
+        .unwrap_or(0.0)
+}
+
+fn compare_str<'a>(pattern: &'a str, de_value: &'a str) -> f64 {
+    let lcsstr = textdistance::str::lcsstr(pattern, de_value);
+
+    lcsstr as f64 / (max(pattern.len(), de_value.len())) as f64
+}
+
+/// From 0 to 1.
+/// 1 is a perfect match.
+fn match_entry_from_id(pattern: &str, de: &DesktopEntry) -> f64 {
+    // (pattern, malus)
+    let mut de_inputs = Vec::with_capacity(4);
+
+    let id = de.appid.to_lowercase();
+
+    if let Some(last_part_of_id) = id.split('.').last() {
+        de_inputs.push((last_part_of_id.to_owned(), 0.06));
+    }
+
+    de_inputs.push((id, 0.));
+
+    if let Some(i) = de.startup_wm_class() {
+        de_inputs.push((i.to_lowercase(), 0.));
+    }
+
+    if let Some(i) = de.exec() {
+        de_inputs.push((i.to_lowercase(), 0.06));
+    }
+
+    de_inputs
+        .iter()
+        .map(|de| (compare_str(pattern, &de.0) - de.1).max(0.))
+        .max_by(|e1, e2| e1.total_cmp(e2))
+        .unwrap_or(0.0)
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchAppIdOptions {
+    /// Minimal score required to validate a match.
+    /// Must be between 0 and 1
+    pub min_score: f64,
+    /// Optional field to lower the minimal score required to match
+    /// if the entropy is at a certain value, e.i if the two best matches
+    /// hare very different.
+    /// - First element - minimal entropy, between 0 and 1
+    /// - Second element - minimal score, between 0 and 1
+    pub entropy: Option<(f64, f64)>,
+}
+
+impl Default for MatchAppIdOptions {
+    fn default() -> Self {
+        Self {
+            min_score: 0.15,
+            entropy: Some((0.15, 0.1)),
+        }
+    }
+}
+
+/// Return the best match over all provided [`DesktopEntry`].
+/// Use this to match over the values provided by the compositor, not the user.
+/// First entries get the priority.
+pub fn get_best_match<'a, I>(
+    patterns: &[I],
+    entries: &'a [DesktopEntry<'a>],
+    options: MatchAppIdOptions,
+) -> Option<&'a DesktopEntry<'a>>
+where
+    I: AsRef<str>,
+{
+    let mut max_score = None;
+    let mut second_max_score = 0.;
+
+    let normalized_patterns = patterns
+        .iter()
+        .map(|e| e.as_ref().to_lowercase())
+        .inspect(|e| {
+            debug!("searching with {}", e);
+        })
+        .collect::<Vec<_>>();
+
+    for de in entries {
+        let score = normalized_patterns
+            .iter()
+            .map(|p| match_entry_from_id(p, de))
+            .max_by(|e1, e2| e1.total_cmp(e2))
+            .unwrap_or(0.0);
+
+        match max_score {
+            Some((prev_max_score, _)) => {
+                if prev_max_score < score {
+                    debug!(
+                        "found {} for {}. Score: {}",
+                        de.appid,
+                        patterns[0].as_ref(),
+                        score
+                    );
+                    second_max_score = prev_max_score;
+                    max_score = Some((score, de));
+                }
+            }
+            None => {
+                debug!(
+                    "found: {} for {}. Score: {}",
+                    de.appid,
+                    patterns[0].as_ref(),
+                    score
+                );
+                max_score = Some((score, de));
+            }
+        }
+
+        if score > 0.99 {
+            break;
+        }
+    }
+
+    if let Some((max_score, de)) = max_score {
+        if max_score > options.min_score {
+            Some(de)
+        } else if let Some((min_entropy, min_score_entropy)) = options.entropy {
+            let entropy = max_score - second_max_score;
+
+            if entropy > min_entropy && max_score > min_score_entropy {
+                Some(de)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{default_paths, get_languages_from_env, matching::compare_str, DesktopEntry, Iter};
+
+    use super::{get_best_match, MatchAppIdOptions};
+
+    #[test]
+    fn find_de() {
+        let entries =
+            DesktopEntry::from_paths(Iter::new(default_paths()), Some(&get_languages_from_env()))
+                .filter_map(|e| e.ok())
+                .collect::<Vec<_>>();
+
+        let e = get_best_match(&["gnome-disks"], &entries, MatchAppIdOptions::default());
+
+        println!("found {}", e.unwrap().appid);
+    }
+    #[test]
+    fn a() {
+        let res = compare_str("org.gnome.tweaks", "gnome.disks");
+
+        println!("{res}")
+    }
+}


### PR DESCRIPTION
This make sense to have a function that does this here because the match of desktop entries is not trivial (this could even become more complex once we add weights (#22). And this is used in 2 parts on the cosmic DE (app library and launcher)

CC @Drakulix 