### PR TITLE
fix: error on equal sign only for first argument

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -62,10 +62,6 @@ impl<'a> DesktopEntry<'a> {
             return Err(ExecError::ExecFieldNotFound);
         };
 
-        if exec.contains('=') {
-            return Err(ExecError::WrongFormat("equal sign detected".into()));
-        }
-
         let exec = if let Some(without_prefix) = exec.strip_prefix('\"') {
             without_prefix
                 .strip_suffix('\"')
@@ -112,6 +108,10 @@ impl<'a> DesktopEntry<'a> {
 
         if args.is_empty() {
             return Err(ExecError::ExecFieldIsEmpty);
+        }
+
+        if args.first().unwrap().contains('=') {
+            return Err(ExecError::WrongFormat("equal sign detected".into()));
         }
 
         Ok(args)


### PR DESCRIPTION
According to FDO desktop entry spec, only first argument may not contain equal sign.
https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html

Current behaviour breaks desktop entries that specify equal sign in parameters, e.g.:

```
❯ bat /var/lib/flatpak/exports/share/applications/org.chromium.Chromium.desktop | grep Exec
Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=/app/bin/chromium --file-forwarding org.chromium.Chromium @@u %U @@
```