### PR TITLE
change the order of DefaultPath + Iter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,14 @@
 This crate provides a library for efficiently parsing [Desktop Entry](https://specifications.freedesktop.org/desktop-entry-spec/latest/index.html) files.
 
 ```rust
-use std::fs;
-
-use freedesktop_desktop_entry::{
-    default_paths, get_languages_from_env, DesktopEntry, Iter, PathSource,
-};
+use freedesktop_desktop_entry::{default_paths, get_languages_from_env, Iter, PathSource};
 
 fn main() {
     let locales = get_languages_from_env();
-
-    for path in Iter::new(default_paths()) {
-        let path_src = PathSource::guess_from(&path);
-        if let Ok(bytes) = fs::read_to_string(&path) {
-            if let Ok(entry) = DesktopEntry::from_str(&path, &bytes, &locales) {
-                println!("{:?}: {}\n---\n{}", path_src, path.display(), entry);
-            }
-        }
+    for entry in Iter::new(default_paths()).entries(Some(&locales)) {
+        let path_src = PathSource::guess_from(&entry.path);
+        
+        println!("{:?}: {}\n---\n{}", path_src, entry.path.display(), entry);
     }
 }
 ```

--- a/examples/all_files.rs
+++ b/examples/all_files.rs
@@ -1,21 +1,13 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use std::fs;
-
-use freedesktop_desktop_entry::{
-    default_paths, get_languages_from_env, DesktopEntry, Iter, PathSource,
-};
+use freedesktop_desktop_entry::{default_paths, get_languages_from_env, Iter, PathSource};
 
 fn main() {
     let locales = get_languages_from_env();
+    for entry in Iter::new(default_paths()).entries(Some(&locales)) {
+        let path_src = PathSource::guess_from(&entry.path);
 
-    for path in Iter::new(default_paths()) {
-        let path_src = PathSource::guess_from(&path);
-        if let Ok(bytes) = fs::read_to_string(&path) {
-            if let Ok(entry) = DesktopEntry::from_str(&path, &bytes, Some(&locales)) {
-                println!("{:?}: {}\n---\n{}", path_src, path.display(), entry);
-            }
-        }
+        println!("{:?}: {}\n---\n{}", path_src, entry.path.display(), entry);
     }
 }

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -64,9 +64,7 @@ fn bench_owned_optimized(it: u32) {
 
         let now = Instant::now();
 
-        let _ = DesktopEntry::from_paths(paths, Some(&locale))
-            .filter_map(|e| e.ok())
-            .collect::<Vec<_>>();
+        let _ = paths.entries(Some(&locale)).collect::<Vec<_>>();
 
         total_time += now.elapsed();
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -57,19 +57,6 @@ impl<'a> DesktopEntry<'a> {
         })
     }
 
-    pub fn from_paths<'i, 'l: 'i, L>(
-        paths: impl Iterator<Item = PathBuf> + 'i,
-        locales_filter: Option<&'l [L]>,
-    ) -> impl Iterator<Item = Result<DesktopEntry<'static>, DecodeError>> + 'i
-    where
-        L: AsRef<str>,
-    {
-        let mut buf = String::new();
-        let locales_filter = locales_filter.map(add_generic_locales);
-
-        paths.map(move |path| decode_from_path_with_buf(path, locales_filter.as_deref(), &mut buf))
-    }
-
     /// Return an owned [`DesktopEntry`]
     pub fn from_path<L>(
         path: PathBuf,
@@ -163,7 +150,7 @@ fn process_line<'buf, 'local_ref, 'res: 'local_ref + 'buf, F, L>(
 }
 
 #[inline]
-fn decode_from_path_with_buf<L>(
+pub(crate) fn decode_from_path_with_buf<L>(
     path: PathBuf,
     locales_filter: Option<&[L]>,
     buf: &mut String,
@@ -202,7 +189,7 @@ where
 }
 
 /// Ex: if a locale equal fr_FR, add fr
-fn add_generic_locales<L: AsRef<str>>(locales: &[L]) -> Vec<&str> {
+pub(crate) fn add_generic_locales<L: AsRef<str>>(locales: &[L]) -> Vec<&str> {
     let mut v = Vec::with_capacity(locales.len() + 1);
 
     for l in locales {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,18 +1,23 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{fs, path::PathBuf};
+use std::{collections::VecDeque, fs, path::PathBuf};
+
+use crate::{
+    decoder::{add_generic_locales, decode_from_path_with_buf},
+    DesktopEntry,
+};
 
 pub struct Iter {
-    directories_to_walk: Vec<PathBuf>,
+    directories_to_walk: VecDeque<PathBuf>,
     actively_walking: Option<fs::ReadDir>,
 }
 
 impl Iter {
-    /// Directories will be processed in order, starting from the end.
-    pub fn new(directories_to_walk: Vec<PathBuf>) -> Self {
+    /// Directories will be processed in order.
+    pub fn new<I: Iterator<Item = PathBuf>>(directories_to_walk: I) -> Self {
         Self {
-            directories_to_walk,
+            directories_to_walk: directories_to_walk.collect(),
             actively_walking: None,
         }
     }
@@ -26,7 +31,7 @@ impl Iterator for Iter {
             let mut iterator = match self.actively_walking.take() {
                 Some(dir) => dir,
                 None => {
-                    while let Some(path) = self.directories_to_walk.pop() {
+                    while let Some(path) = self.directories_to_walk.pop_front() {
                         match fs::read_dir(&path) {
                             Ok(directory) => {
                                 self.actively_walking = Some(directory);
@@ -53,7 +58,7 @@ impl Iterator for Iter {
 
                     if let Ok(file_type) = entry.file_type() {
                         if file_type.is_dir() {
-                            self.directories_to_walk.push(path);
+                            self.directories_to_walk.push_front(path);
                         } else if file_type.is_file()
                             && path.extension().map_or(false, |ext| ext == "desktop")
                         {
@@ -64,5 +69,21 @@ impl Iterator for Iter {
                 }
             }
         }
+    }
+}
+
+impl Iter {
+    pub fn entries<'i, 'l: 'i, L>(
+        self,
+        locales_filter: Option<&'l [L]>,
+    ) -> impl Iterator<Item = DesktopEntry<'static>> + 'i
+    where
+        L: AsRef<str>,
+    {
+        let mut buf = String::new();
+        let locales_filter = locales_filter.map(add_generic_locales);
+
+        self.map(move |path| decode_from_path_with_buf(path, locales_filter.as_deref(), &mut buf))
+            .filter_map(|e| e.ok())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,20 +411,16 @@ impl PathSource {
 
 /// Returns the default paths in which desktop entries should be searched for based on the current
 /// environment.
-/// Paths are sorted by priority, in reverse, e.i the path with the greater priority will be at the end.
+/// Paths are sorted by priority.
 ///
 /// Panics in case determining the current home directory fails.
-pub fn default_paths() -> Vec<PathBuf> {
+pub fn default_paths() -> impl Iterator<Item = PathBuf> {
     let base_dirs = BaseDirectories::new().unwrap();
     let mut data_dirs: Vec<PathBuf> = vec![];
     data_dirs.push(base_dirs.get_data_home());
     data_dirs.append(&mut base_dirs.get_data_dirs());
 
-    data_dirs
-        .iter()
-        .map(|d| d.join("applications"))
-        .rev()
-        .collect()
+    data_dirs.into_iter().map(|d| d.join("applications"))
 }
 
 pub(crate) fn dgettext(domain: &str, message: &str) -> String {


### PR DESCRIPTION
This pr remove the oddiness of the `default_paths` function and `Iter`, which were processing path in reverse order.
I was causing problem in the `default_paths` function itself, but also in cosmic-applet (https://github.com/pop-os/cosmic-applets/blob/0b536349cb1a27b91e3ab0650931cd531f536ebd/cosmic-panel-button/src/main.rs#L157) .


Also, i added an helper function `entries` on `Iter`. Probably better than the previous `from_paths` function.
And fixed the code in the README