### PR TITLE
Remove lifetime, and some functions on Group and fix escaped char

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ categories = [ "os::unix-apis" ]
 keywords = [ "freedesktop", "desktop", "entry" ]
 
 [dependencies]
-dirs = "5.0.1"
+dirs = "5"
 gettext-rs = { version = "0.7", features = ["gettext-system"]}
 memchr = "2"
-textdistance = "1.0.2"
-strsim = "0.11.1"
-thiserror = "1"
-xdg = "2.4.0"
-log = "0.4.21"
+textdistance = "1"
+strsim = "0.11"
+thiserror = "2"
+xdg = "2"
+log = "0.4"
+cached = "0.54"
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ use freedesktop_desktop_entry::{default_paths, get_languages_from_env, Iter, Pat
 
 fn main() {
     let locales = get_languages_from_env();
-    for entry in Iter::new(default_paths()).entries(Some(&locales)) {
+
+    let entries = Iter::new(default_paths())
+        .entries(Some(&locales))
+        .collect::<Vec<_>>();
+    
+    for entry in entries {
         let path_src = PathSource::guess_from(&entry.path);
-        
+
         println!("{:?}: {}\n---\n{}", path_src, entry.path.display(), entry);
     }
 }
+
 ```
 
 ## License

--- a/examples/all_files.rs
+++ b/examples/all_files.rs
@@ -5,7 +5,12 @@ use freedesktop_desktop_entry::{default_paths, get_languages_from_env, Iter, Pat
 
 fn main() {
     let locales = get_languages_from_env();
-    for entry in Iter::new(default_paths()).entries(Some(&locales)) {
+
+    let entries = Iter::new(default_paths())
+        .entries(Some(&locales))
+        .collect::<Vec<_>>();
+    
+    for entry in entries {
         let path_src = PathSource::guess_from(&entry.path);
 
         println!("{:?}: {}\n---\n{}", path_src, entry.path.display(), entry);

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -31,8 +31,5 @@ fn bench(it: u32) {
         total_time += now.elapsed();
     }
 
-    println!("bench_borrowed: {:.2?}", total_time / it);
+    println!("time to parse all .desktop files: {:.2?}", total_time / it);
 }
-
-
-

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,12 +10,10 @@ use std::time::Instant;
 fn main() {
     let it = 500;
 
-    bench_borrowed(it);
-    bench_owned(it);
-    bench_owned_optimized(it);
+    bench(it);
 }
 
-fn bench_borrowed(it: u32) {
+fn bench(it: u32) {
     let mut total_time = Duration::ZERO;
 
     for _ in 0..it {
@@ -36,38 +34,5 @@ fn bench_borrowed(it: u32) {
     println!("bench_borrowed: {:.2?}", total_time / it);
 }
 
-fn bench_owned(it: u32) {
-    let mut total_time = Duration::ZERO;
 
-    for _ in 0..it {
-        let locale = get_languages_from_env();
-        let paths = Iter::new(default_paths());
 
-        let now = Instant::now();
-
-        for path in paths {
-            if let Ok(_entry) = DesktopEntry::from_path(path, Some(&locale)) {}
-        }
-
-        total_time += now.elapsed();
-    }
-
-    println!("bench_owned: {:.2?}", total_time / it);
-}
-
-fn bench_owned_optimized(it: u32) {
-    let mut total_time = Duration::ZERO;
-
-    for _ in 0..it {
-        let locale = get_languages_from_env();
-        let paths = Iter::new(default_paths());
-
-        let now = Instant::now();
-
-        let _ = paths.entries(Some(&locale)).collect::<Vec<_>>();
-
-        total_time += now.elapsed();
-    }
-
-    println!("bench_owned_optimized: {:.2?}", total_time / it);
-}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fs::File,
-    io::{self, BufRead},
+    fs::{self},
     path::{Path, PathBuf},
 };
 
-use crate::DesktopEntry;
+use crate::{DesktopEntry, Group};
 use crate::{Groups, LocaleMap};
 use thiserror::Error;
 
@@ -19,21 +16,34 @@ pub enum DecodeError {
     AppID,
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("MultipleGroupWithSameName")]
+    MultipleGroupWithSameName,
+    #[error("MultipleKeysWithSameName")]
+    MultipleKeysWithSameName,
+    #[error("KeyValueWithoutAGroup")]
+    KeyValueWithoutAGroup,
+    #[error("InvalidKey. Accepted: A-Za-z0-9")]
+    InvalidKey,
+    #[error("KeyDoesNotExist, this can happens when a localized key has no default value")]
+    KeyDoesNotExist,
 }
 
-impl<'a> DesktopEntry<'a> {
+impl DesktopEntry {
     pub fn from_str<L>(
-        path: &'a Path,
-        input: &'a str,
+        path: impl Into<PathBuf>,
+        input: &str,
         locales_filter: Option<&[L]>,
-    ) -> Result<DesktopEntry<'a>, DecodeError>
+    ) -> Result<DesktopEntry, DecodeError>
     where
         L: AsRef<str>,
     {
-        let appid = get_app_id(path)?;
+        let path: PathBuf = path.into();
+
+        let appid = get_app_id(&path)?;
 
         let mut groups = Groups::default();
-        let mut active_group = Cow::Borrowed("");
+        let mut active_group: Option<ActiveGroup> = None;
+        let mut active_keys: Option<ActiveKeys> = None;
         let mut ubuntu_gettext_domain = None;
 
         let locales_filter = locales_filter.map(add_generic_locales);
@@ -43,31 +53,56 @@ impl<'a> DesktopEntry<'a> {
                 line,
                 &mut groups,
                 &mut active_group,
+                &mut active_keys,
                 &mut ubuntu_gettext_domain,
                 locales_filter.as_deref(),
-                Cow::Borrowed,
-            )
+            )?
+        }
+
+        if let Some(active_keys) = active_keys.take() {
+            match &mut active_group {
+                Some(active_group) => {
+                    if active_group
+                        .group
+                        .0
+                        .insert(
+                            active_keys.key_name,
+                            (active_keys.default_value, active_keys.locales),
+                        )
+                        .is_some()
+                    {
+                        return Err(DecodeError::MultipleKeysWithSameName);
+                    }
+                }
+                None => return Err(DecodeError::KeyValueWithoutAGroup),
+            }
+        }
+
+        if let Some(group) = active_group.take() {
+            if groups.0.insert(group.group_name, group.group).is_some() {
+                return Err(DecodeError::MultipleGroupWithSameName);
+            }
         }
 
         Ok(DesktopEntry {
-            appid: Cow::Borrowed(appid),
+            appid: appid.to_string(),
             groups,
-            path: Cow::Borrowed(path),
+            path,
             ubuntu_gettext_domain,
         })
     }
 
     /// Return an owned [`DesktopEntry`]
     pub fn from_path<L>(
-        path: PathBuf,
+        path: impl Into<PathBuf>,
         locales_filter: Option<&[L]>,
-    ) -> Result<DesktopEntry<'static>, DecodeError>
+    ) -> Result<DesktopEntry, DecodeError>
     where
         L: AsRef<str>,
     {
-        let mut buf = String::new();
-        let locales_filter = locales_filter.map(add_generic_locales);
-        decode_from_path_with_buf(path, locales_filter.as_deref(), &mut buf)
+        let path: PathBuf = path.into();
+        let input = fs::read_to_string(&path)?;
+        Self::from_str(path, &input, locales_filter)
     }
 }
 
@@ -81,115 +116,140 @@ fn get_app_id<P: AsRef<Path> + ?Sized>(path: &P) -> Result<&str, DecodeError> {
     Ok(appid)
 }
 
+#[derive(Debug)]
+struct ActiveGroup {
+    group_name: String,
+    group: Group,
+}
+
+#[derive(Debug)]
+struct ActiveKeys {
+    key_name: String,
+    default_value: String,
+    locales: LocaleMap,
+}
+
 #[inline]
-fn process_line<'buf, 'local_ref, 'res: 'local_ref + 'buf, F, L>(
-    line: &'buf str,
-    groups: &'local_ref mut Groups<'res>,
-    active_group: &'local_ref mut Cow<'res, str>,
-    ubuntu_gettext_domain: &'local_ref mut Option<Cow<'res, str>>,
+fn process_line<L: AsRef<str>>(
+    line: &str,
+    groups: &mut Groups,
+    active_group: &mut Option<ActiveGroup>,
+    active_keys: &mut Option<ActiveKeys>,
+    ubuntu_gettext_domain: &mut Option<String>,
     locales_filter: Option<&[L]>,
-    convert_to_cow: F,
-) where
-    F: Fn(&'buf str) -> Cow<'res, str>,
-    L: AsRef<str>,
-{
-    let line = line.trim();
-    if line.is_empty() || line.starts_with('#') {
-        return;
+) -> Result<(), DecodeError> {
+    if line.trim().is_empty() || line.starts_with('#') {
+        return Ok(());
     }
 
     let line_bytes = line.as_bytes();
 
     if line_bytes[0] == b'[' {
         if let Some(end) = memchr::memrchr(b']', &line_bytes[1..]) {
-            *active_group = convert_to_cow(&line[1..end + 1]);
+            let group_name = &line[1..end + 1];
+
+            if let Some(active_keys) = active_keys.take() {
+                match active_group {
+                    Some(active_group) => {
+                        if active_group
+                            .group
+                            .0
+                            .insert(
+                                active_keys.key_name,
+                                (active_keys.default_value, active_keys.locales),
+                            )
+                            .is_some()
+                        {
+                            dbg!(&active_group.group);
+                            return Err(DecodeError::MultipleKeysWithSameName);
+                        }
+                    }
+                    None => return Err(DecodeError::KeyValueWithoutAGroup),
+                }
+            }
+
+            if let Some(group) = active_group.take() {
+                if groups.0.insert(group.group_name, group.group).is_some() {
+                    return Err(DecodeError::MultipleGroupWithSameName);
+                }
+            }
+
+            active_group.replace(ActiveGroup {
+                group_name: group_name.to_string(),
+                group: Group::default(),
+            });
         }
     } else if let Some(delimiter) = memchr::memchr(b'=', line_bytes) {
         let key = &line[..delimiter];
         let value = &line[delimiter + 1..];
 
+        if key.is_empty() {
+            return Err(DecodeError::InvalidKey);
+        }
+
         // if locale
         if key.as_bytes()[key.len() - 1] == b']' {
             if let Some(start) = memchr::memchr(b'[', key.as_bytes()) {
-                let key_name = &key[..start];
+                // verify that the name is the same of active key ?
+                // or we can assume this is the case
+                // let local_key = &key[..start];
+
                 let locale = &key[start + 1..key.len() - 1];
 
                 match locales_filter {
                     Some(locales_filter)
                         if !locales_filter.iter().any(|l| l.as_ref() == locale) =>
                     {
-                        return
+                        return Ok(())
                     }
                     _ => (),
                 }
 
-                groups
-                    .0
-                    .entry(active_group.clone())
-                    .or_default()
-                    .0
-                    .entry(convert_to_cow(key_name))
-                    .or_insert_with(|| (Cow::Borrowed(""), LocaleMap::new()))
-                    .1
-                    .insert(convert_to_cow(locale), convert_to_cow(value));
+                match active_keys {
+                    Some(active_keys) => {
+                        active_keys
+                            .locales
+                            .insert(locale.to_string(), value.to_string());
+                    }
+                    None => return Err(DecodeError::KeyDoesNotExist),
+                }
 
-                return;
+                return Ok(());
             }
         }
 
         if key == "X-Ubuntu-Gettext-Domain" {
-            *ubuntu_gettext_domain = Some(convert_to_cow(value));
-            return;
+            *ubuntu_gettext_domain = Some(value.to_string());
+            return Ok(());
         }
 
-        groups
-            .0
-            .entry(active_group.clone())
-            .or_default()
-            .0
-            .entry(convert_to_cow(key))
-            .or_insert_with(|| (Cow::Borrowed(""), BTreeMap::new()))
-            .0 = convert_to_cow(value);
+        if let Some(active_keys) = active_keys.take() {
+            match active_group {
+                Some(active_group) => {
+                    if active_group
+                        .group
+                        .0
+                        .insert(
+                            active_keys.key_name,
+                            (active_keys.default_value, active_keys.locales),
+                        )
+                        .is_some()
+                    {
+                        dbg!(&active_group.group);
+                        return Err(DecodeError::MultipleKeysWithSameName);
+                    }
+                }
+                None => return Err(DecodeError::KeyValueWithoutAGroup),
+            }
+        }
+        active_keys.replace(ActiveKeys {
+            // todo: verify that the key only contains A-Za-z0-9 ?
+            key_name: key.trim().to_string(),
+            default_value: value.trim_start().to_string(),
+            locales: LocaleMap::default(),
+        });
     }
-}
-
-#[inline]
-pub(crate) fn decode_from_path_with_buf<L>(
-    path: PathBuf,
-    locales_filter: Option<&[L]>,
-    buf: &mut String,
-) -> Result<DesktopEntry<'static>, DecodeError>
-where
-    L: AsRef<str>,
-{
-    let file = File::open(&path)?;
-
-    let appid = get_app_id(&path)?;
-
-    let mut groups = Groups::default();
-    let mut active_group = Cow::Borrowed("");
-    let mut ubuntu_gettext_domain = None;
-
-    let mut reader = io::BufReader::new(file);
-
-    while reader.read_line(buf)? != 0 {
-        process_line(
-            buf,
-            &mut groups,
-            &mut active_group,
-            &mut ubuntu_gettext_domain,
-            locales_filter,
-            |s| Cow::Owned(s.to_owned()),
-        );
-        buf.clear();
-    }
-
-    Ok(DesktopEntry {
-        appid: Cow::Owned(appid.to_owned()),
-        groups,
-        path: Cow::Owned(path),
-        ubuntu_gettext_domain,
-    })
+    Ok(())
 }
 
 /// Ex: if a locale equal fr_FR, add fr

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -32,7 +32,7 @@ impl<'a> DesktopEntry<'a> {
     {
         let appid = get_app_id(path)?;
 
-        let mut groups = Groups::new();
+        let mut groups = Groups::default();
         let mut active_group = Cow::Borrowed("");
         let mut ubuntu_gettext_domain = None;
 
@@ -124,8 +124,10 @@ fn process_line<'buf, 'local_ref, 'res: 'local_ref + 'buf, F, L>(
                 }
 
                 groups
+                    .0
                     .entry(active_group.clone())
                     .or_default()
+                    .0
                     .entry(convert_to_cow(key_name))
                     .or_insert_with(|| (Cow::Borrowed(""), LocaleMap::new()))
                     .1
@@ -141,8 +143,10 @@ fn process_line<'buf, 'local_ref, 'res: 'local_ref + 'buf, F, L>(
         }
 
         groups
+            .0
             .entry(active_group.clone())
             .or_default()
+            .0
             .entry(convert_to_cow(key))
             .or_insert_with(|| (Cow::Borrowed(""), BTreeMap::new()))
             .0 = convert_to_cow(value);
@@ -162,7 +166,7 @@ where
 
     let appid = get_app_id(&path)?;
 
-    let mut groups = Groups::new();
+    let mut groups = Groups::default();
     let mut active_group = Cow::Borrowed("");
     let mut ubuntu_gettext_domain = None;
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -16,7 +16,7 @@ pub enum ExecError {
     ExecFieldNotFound,
 }
 
-impl<'a> DesktopEntry<'a> {
+impl DesktopEntry {
     pub fn parse_exec(&self) -> Result<Vec<String>, ExecError> {
         self.get_args(self.exec(), &[], &[] as &[&str])
     }
@@ -24,7 +24,7 @@ impl<'a> DesktopEntry<'a> {
     /// Macros like `%f` (cf [.desktop spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)) will be subtitued using the `uris` parameter.
     pub fn parse_exec_with_uris<L>(
         &self,
-        uris: &[&'a str],
+        uris: &[&str],
         locales: &[L],
     ) -> Result<Vec<String>, ExecError>
     where
@@ -40,7 +40,7 @@ impl<'a> DesktopEntry<'a> {
     pub fn parse_exec_action_with_uris<L>(
         &self,
         action_name: &str,
-        uris: &[&'a str],
+        uris: &[&str],
         locales: &[L],
     ) -> Result<Vec<String>, ExecError>
     where
@@ -50,9 +50,9 @@ impl<'a> DesktopEntry<'a> {
     }
 
     fn get_args<L>(
-        &'a self,
-        exec: Option<&'a str>,
-        uris: &[&'a str],
+        &self,
+        exec: Option<&str>,
+        uris: &[&str],
         locales: &[L],
     ) -> Result<Vec<String>, ExecError>
     where

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,10 +3,7 @@
 
 use std::{collections::VecDeque, fs, path::PathBuf};
 
-use crate::{
-    decoder::{add_generic_locales, decode_from_path_with_buf},
-    DesktopEntry,
-};
+use crate::DesktopEntry;
 
 pub struct Iter {
     directories_to_walk: VecDeque<PathBuf>,
@@ -76,14 +73,11 @@ impl Iter {
     pub fn entries<'i, 'l: 'i, L>(
         self,
         locales_filter: Option<&'l [L]>,
-    ) -> impl Iterator<Item = DesktopEntry<'static>> + 'i
+    ) -> impl Iterator<Item = DesktopEntry> + 'i
     where
         L: AsRef<str>,
     {
-        let mut buf = String::new();
-        let locales_filter = locales_filter.map(add_generic_locales);
-
-        self.map(move |path| decode_from_path_with_buf(path, locales_filter.as_deref(), &mut buf))
+        self.map(move |path| DesktopEntry::from_path(path, locales_filter))
             .filter_map(|e| e.ok())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,30 +19,26 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use xdg::BaseDirectories;
 
-pub type GroupName<'a> = Cow<'a, str>;
+pub type GroupName = String;
 #[derive(Debug, Clone, Default)]
-pub struct Groups<'a>(pub BTreeMap<GroupName<'a>, Group<'a>>);
+pub struct Groups(pub BTreeMap<GroupName, Group>);
 
-impl<'a> Groups<'a> {
-    pub fn desktop_entry(&self) -> Option<&Group<'a>> {
+impl Groups {
+    pub fn desktop_entry(&self) -> Option<&Group> {
         self.0.get("Desktop Entry")
     }
 
-    pub fn group(&self, key: &str) -> Option<&Group<'a>> {
+    pub fn group(&self, key: &str) -> Option<&Group> {
         self.0.get(key)
     }
 }
 
-pub type Key<'a> = Cow<'a, str>;
+pub type Key = String;
 #[derive(Debug, Clone, Default)]
-pub struct Group<'a>(pub BTreeMap<Key<'a>, (Value<'a>, LocaleMap<'a>)>);
+pub struct Group(pub BTreeMap<Key, (Value, LocaleMap)>);
 
-impl<'input> Group<'input> {
-    pub fn localized_entry<'this: 'input, 'key, L: AsRef<str>>(
-        &'this self,
-        key: &'key str,
-        locales: &[L],
-    ) -> Option<&'input str> {
+impl Group {
+    pub fn localized_entry<L: AsRef<str>>(&self, key: &str, locales: &[L]) -> Option<&str> {
         let (default_value, locale_map) = self.0.get(key)?;
 
         for locale in locales {
@@ -74,99 +70,60 @@ impl<'input> Group<'input> {
     }
 }
 
-pub type Locale<'a> = Cow<'a, str>;
-pub type LocaleMap<'a> = BTreeMap<Locale<'a>, Value<'a>>;
-pub type Value<'a> = Cow<'a, str>;
+pub type Locale = String;
+pub type LocaleMap = BTreeMap<Locale, Value>;
+pub type Value = String;
 
 #[derive(Debug, Clone)]
-pub struct DesktopEntry<'a> {
-    pub appid: Cow<'a, str>,
-    pub groups: Groups<'a>,
-    pub path: Cow<'a, Path>,
-    pub ubuntu_gettext_domain: Option<Cow<'a, str>>,
+pub struct DesktopEntry {
+    pub appid: String,
+    pub groups: Groups,
+    pub path: PathBuf,
+    pub ubuntu_gettext_domain: Option<String>,
 }
 
-impl Eq for DesktopEntry<'_> {}
+impl Eq for DesktopEntry {}
 
-impl Hash for DesktopEntry<'_> {
+impl Hash for DesktopEntry {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.appid.hash(state);
     }
 }
 
-impl PartialEq for DesktopEntry<'_> {
+impl PartialEq for DesktopEntry {
     fn eq(&self, other: &Self) -> bool {
         self.appid == other.appid
     }
 }
 
-impl DesktopEntry<'_> {
+impl DesktopEntry {
     /// Construct a new [`DesktopEntry`] from an appid. The name field will be
     /// set to that appid.
-    pub fn from_appid(appid: &str) -> DesktopEntry<'_> {
+    pub fn from_appid(appid: String) -> DesktopEntry {
+        let name = appid.split('.').next_back().unwrap_or(&appid).to_string();
+
         let mut de = DesktopEntry {
-            appid: Cow::Borrowed(appid),
+            appid,
             groups: Groups::default(),
-            path: Cow::Owned(PathBuf::from("")),
+            path: PathBuf::from(""),
             ubuntu_gettext_domain: None,
         };
-        de.add_desktop_entry("Name", appid);
+        de.add_desktop_entry("Name".to_string(), name);
         de
     }
 }
 
-impl<'a> DesktopEntry<'a> {
-    // note that we shoudn't implement ToOwned in this case: https://stackoverflow.com/questions/72105604/implement-toowned-for-user-defined-types
-    pub fn to_owned(&self) -> DesktopEntry<'static> {
-        let mut new_groups = Groups::default();
-
-        for (group_name, group) in &self.groups.0 {
-            let mut new_key_map = Group::default();
-
-            for (key, (value, locale_map)) in &group.0 {
-                let mut new_locale_map = LocaleMap::new();
-
-                for (locale, value) in locale_map {
-                    new_locale_map.insert(
-                        Cow::Owned(locale.to_string()),
-                        Cow::Owned(value.to_string()),
-                    );
-                }
-
-                new_key_map.0.insert(
-                    Cow::Owned(key.to_string()),
-                    (Cow::Owned(value.to_string()), new_locale_map),
-                );
-            }
-
-            new_groups
-                .0
-                .insert(Cow::Owned(group_name.to_string()), new_key_map);
-        }
-
-        DesktopEntry {
-            appid: Cow::Owned(self.appid.to_string()),
-            groups: new_groups,
-            ubuntu_gettext_domain: self
-                .ubuntu_gettext_domain
-                .as_ref()
-                .map(|ubuntu_gettext_domain| Cow::Owned(ubuntu_gettext_domain.to_string())),
-            path: Cow::Owned(self.path.to_path_buf()),
-        }
-    }
-}
-
-impl<'a> DesktopEntry<'a> {
-    pub fn id(&'a self) -> &'a str {
+impl DesktopEntry {
+    pub fn id(&self) -> &str {
         self.appid.as_ref()
     }
 
     /// A desktop entry field if any field under the `[Desktop Entry]` section.
-    pub fn desktop_entry(&'a self, key: &str) -> Option<&'a str> {
-        Self::entry(self.groups.desktop_entry(), key)
+    pub fn desktop_entry(&self, key: &str) -> Option<&str> {
+        self.groups.desktop_entry()?.entry(key)
     }
 
-    pub fn desktop_entry_localized<L: AsRef<str>>(
+    pub fn desktop_entry_localized<'a, L: AsRef<str>>(
         &'a self,
         key: &str,
         locales: &[L],
@@ -181,13 +138,9 @@ impl<'a> DesktopEntry<'a> {
 
     /// Insert a new field to this [`DesktopEntry`], in the `[Desktop Entry]` section, removing
     /// the previous value and locales in any.
-    pub fn add_desktop_entry<'b>(&'b mut self, key: &'a str, value: &'a str)
-    where
-        'a: 'b,
-    {
+    pub fn add_desktop_entry(&mut self, key: String, value: String) {
         let action_key = "Desktop Entry";
-        let key = Cow::Borrowed(key);
-        let value = (Cow::Borrowed(value), LocaleMap::default());
+        let value = (value, LocaleMap::default());
 
         match self.groups.0.get_mut(action_key) {
             Some(keymap) => {
@@ -196,88 +149,88 @@ impl<'a> DesktopEntry<'a> {
             None => {
                 let mut keymap = Group::default();
                 keymap.0.insert(key, value);
-                self.groups.0.insert(Cow::Borrowed(action_key), keymap);
+                self.groups.0.insert(action_key.to_string(), keymap);
             }
         }
     }
 
-    pub fn name<L: AsRef<str>>(&'a self, locales: &[L]) -> Option<Cow<'a, str>> {
+    pub fn name<L: AsRef<str>>(&self, locales: &[L]) -> Option<Cow<'_, str>> {
         self.desktop_entry_localized("Name", locales)
     }
 
-    pub fn generic_name<L: AsRef<str>>(&'a self, locales: &[L]) -> Option<Cow<'a, str>> {
+    pub fn generic_name<L: AsRef<str>>(&self, locales: &[L]) -> Option<Cow<'_, str>> {
         self.desktop_entry_localized("GenericName", locales)
     }
 
-    pub fn icon(&'a self) -> Option<&'a str> {
+    pub fn icon(&self) -> Option<&str> {
         self.desktop_entry("Icon")
     }
 
     /// This is an human readable description of the desktop file.
-    pub fn comment<L: AsRef<str>>(&'a self, locales: &[L]) -> Option<Cow<'a, str>> {
+    pub fn comment<L: AsRef<str>>(&self, locales: &[L]) -> Option<Cow<str>> {
         self.desktop_entry_localized("Comment", locales)
     }
 
-    pub fn exec(&'a self) -> Option<&'a str> {
+    pub fn exec(&self) -> Option<&str> {
         self.desktop_entry("Exec")
     }
 
     /// Return categories
-    pub fn categories(&'a self) -> Option<Vec<&'a str>> {
+    pub fn categories(&self) -> Option<Vec<&str>> {
         self.desktop_entry("Categories")
             .map(|e| e.split(';').collect())
     }
 
     /// Return keywords
-    pub fn keywords<L: AsRef<str>>(&'a self, locales: &[L]) -> Option<Vec<Cow<'a, str>>> {
+    pub fn keywords<L: AsRef<str>>(&self, locales: &[L]) -> Option<Vec<Cow<str>>> {
         self.localized_entry_splitted(self.groups.desktop_entry(), "Keywords", locales)
     }
 
     /// Return mime types
-    pub fn mime_type(&'a self) -> Option<Vec<&'a str>> {
+    pub fn mime_type(&self) -> Option<Vec<&str>> {
         self.desktop_entry("MimeType")
             .map(|e| e.split(';').collect())
     }
 
-    pub fn no_display(&'a self) -> bool {
+    pub fn no_display(&self) -> bool {
         self.desktop_entry_bool("NoDisplay")
     }
 
-    pub fn only_show_in(&'a self) -> Option<Vec<&'a str>> {
+    pub fn only_show_in(&self) -> Option<Vec<&str>> {
         self.desktop_entry("OnlyShowIn")
             .map(|e| e.split(';').collect())
     }
 
-    pub fn not_show_in(&'a self) -> Option<Vec<&'a str>> {
+    pub fn not_show_in(&self) -> Option<Vec<&str>> {
         self.desktop_entry("NotShowIn")
             .map(|e| e.split(';').collect())
     }
 
-    pub fn flatpak(&'a self) -> Option<&'a str> {
+    pub fn flatpak(&self) -> Option<&str> {
         self.desktop_entry("X-Flatpak")
     }
 
-    pub fn prefers_non_default_gpu(&'a self) -> bool {
+    pub fn prefers_non_default_gpu(&self) -> bool {
         self.desktop_entry_bool("PrefersNonDefaultGPU")
     }
 
-    pub fn startup_notify(&'a self) -> bool {
+    pub fn startup_notify(&self) -> bool {
         self.desktop_entry_bool("StartupNotify")
     }
 
-    pub fn startup_wm_class(&'a self) -> Option<&'a str> {
+    pub fn startup_wm_class(&self) -> Option<&str> {
         self.desktop_entry("StartupWMClass")
     }
 
-    pub fn terminal(&'a self) -> bool {
+    pub fn terminal(&self) -> bool {
         self.desktop_entry_bool("Terminal")
     }
 
-    pub fn type_(&'a self) -> Option<&'a str> {
+    pub fn type_(&self) -> Option<&str> {
         self.desktop_entry("Type")
     }
 
-    pub fn actions(&'a self) -> Option<Vec<&'a str>> {
+    pub fn actions(&self) -> Option<Vec<&str>> {
         self.desktop_entry("Actions")
             .map(|e| e.split(';').collect())
     }
@@ -293,20 +246,18 @@ impl<'a> DesktopEntry<'a> {
     /// ```ignore
     /// entry.action_entry("new-window", "Name")
     /// ```
-    pub fn action_entry(&'a self, action: &str, key: &str) -> Option<&'a str> {
-        let group = self
-            .groups
-            .group(["Desktop Action ", action].concat().as_str());
-
-        Self::entry(group, key)
+    pub fn action_entry(&self, action: &str, key: &str) -> Option<&str> {
+        self.groups
+            .group(["Desktop Action ", action].concat().as_str())?
+            .entry(key)
     }
 
     pub fn action_entry_localized<L: AsRef<str>>(
-        &'a self,
+        &self,
         action: &str,
         key: &str,
         locales: &[L],
-    ) -> Option<Cow<'a, str>> {
+    ) -> Option<Cow<'_, str>> {
         let group = self
             .groups
             .group(["Desktop Action ", action].concat().as_str());
@@ -314,29 +265,21 @@ impl<'a> DesktopEntry<'a> {
         Self::localized_entry(self.ubuntu_gettext_domain.as_deref(), group, key, locales)
     }
 
-    pub fn action_name<L: AsRef<str>>(
-        &'a self,
-        action: &str,
-        locales: &[L],
-    ) -> Option<Cow<'a, str>> {
+    pub fn action_name<L: AsRef<str>>(&self, action: &str, locales: &[L]) -> Option<Cow<str>> {
         self.action_entry_localized(action, "Name", locales)
     }
 
-    pub fn action_exec(&'a self, action: &str) -> Option<&'a str> {
+    pub fn action_exec(&self, action: &str) -> Option<&str> {
         self.action_entry(action, "Exec")
     }
 
-    fn desktop_entry_bool(&'a self, key: &str) -> bool {
+    fn desktop_entry_bool(&self, key: &str) -> bool {
         self.desktop_entry(key).map_or(false, |v| v == "true")
     }
 
-    fn entry(group: Option<&'a Group<'a>>, key: &str) -> Option<&'a str> {
-        group.and_then(|group| group.entry(key))
-    }
-
-    pub(crate) fn localized_entry<L: AsRef<str>>(
-        ubuntu_gettext_domain: Option<&'a str>,
-        group: Option<&'a Group<'a>>,
+    pub(crate) fn localized_entry<'a, L: AsRef<str>>(
+        ubuntu_gettext_domain: Option<&str>,
+        group: Option<&'a Group>,
         key: &str,
         locales: &[L],
     ) -> Option<Cow<'a, str>> {
@@ -344,11 +287,11 @@ impl<'a> DesktopEntry<'a> {
 
         for locale in locales {
             match locale_map.get(locale.as_ref()) {
-                Some(value) => return Some(value.clone()),
+                Some(value) => return Some(Cow::Borrowed(value)),
                 None => {
                     if let Some(pos) = memchr::memchr(b'_', locale.as_ref().as_bytes()) {
                         if let Some(value) = locale_map.get(&locale.as_ref()[..pos]) {
-                            return Some(value.clone());
+                            return Some(Cow::Borrowed(value));
                         }
                     }
                 }
@@ -357,12 +300,12 @@ impl<'a> DesktopEntry<'a> {
         if let Some(domain) = ubuntu_gettext_domain {
             return Some(Cow::Owned(dgettext(domain, default_value)));
         }
-        Some(default_value.clone())
+        Some(Cow::Borrowed(default_value))
     }
 
-    pub fn localized_entry_splitted<L: AsRef<str>>(
+    pub fn localized_entry_splitted<'a, L: AsRef<str>>(
         &self,
-        group: Option<&'a Group<'a>>,
+        group: Option<&'a Group>,
         key: &str,
         locales: &[L],
     ) -> Option<Vec<Cow<'a, str>>> {
@@ -397,7 +340,7 @@ impl<'a> DesktopEntry<'a> {
 
 use std::fmt::{self, Display, Formatter};
 
-impl<'a> Display for DesktopEntry<'a> {
+impl Display for DesktopEntry {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         for (group_name, group) in &self.groups.0 {
             let _ = writeln!(formatter, "[{}]", group_name);
@@ -516,7 +459,7 @@ pub fn current_desktop() -> Option<Vec<String>> {
 #[test]
 fn add_field() {
     let appid = "appid";
-    let de = DesktopEntry::from_appid(appid);
+    let de = DesktopEntry::from_appid(appid.to_string());
 
     assert_eq!(de.appid, appid);
     assert_eq!(de.name(&[] as &[&str]).unwrap(), appid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod decoder;
 mod iter;
 
 mod exec;
+use cached::proc_macro::cached;
 pub use exec::ExecError;
 
 pub mod matching;
@@ -431,6 +432,7 @@ pub(crate) fn dgettext(domain: &str, message: &str) -> String {
 
 /// Get the configured user language env variables.
 /// See https://wiki.archlinux.org/title/Locale#LANG:_default_locale for more information
+#[cached]
 pub fn get_languages_from_env() -> Vec<String> {
     let mut l = Vec::new();
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -42,11 +42,11 @@ impl<'a> DesktopEntry<'a> {
                 .map(|val| val.to_lowercase()),
         );
 
-        let desktop_entry_group = self.groups.get("Desktop Entry");
+        let desktop_entry_group = self.groups.group("Desktop Entry");
 
         for field in fields {
             if let Some(group) = desktop_entry_group {
-                if let Some((default_value, locale_map)) = group.get(field.0) {
+                if let Some((default_value, locale_map)) = group.0.get(field.0) {
                     add_value(&mut normalized_values, default_value, field.1);
 
                     let mut at_least_one_locale = false;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -104,7 +104,7 @@ impl<'a> DesktopEntry<'a> {
 /// Return the corresponding [`DesktopEntry`] that match the given appid.
 pub fn find_entry_from_appid<'a, I>(entries: I, appid: &str) -> Option<&'a DesktopEntry<'a>>
 where
-    I: Iterator<Item = &'a DesktopEntry<'a>>,
+    I: IntoIterator<Item = &'a DesktopEntry<'a>>,
 {
     let normalized_appid = appid.to_lowercase();
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -3,14 +3,14 @@
 
 use crate::DesktopEntry;
 
-impl<'a> DesktopEntry<'a> {
+impl DesktopEntry {
     /// The returned value is between 0.0 and 1.0 (higher value means more similar).
     /// You can use the `additional_haystack_values` parameter to add relevant string that are not part of the desktop entry.
     pub fn match_query<Q, L>(
-        &'a self,
+        &self,
         query: Q,
-        locales: &'a [L],
-        additional_haystack_values: &'a [&'a str],
+        locales: &[L],
+        additional_haystack_values: &[&str],
     ) -> f64
     where
         Q: AsRef<str>,
@@ -102,9 +102,9 @@ impl<'a> DesktopEntry<'a> {
 }
 
 /// Return the corresponding [`DesktopEntry`] that match the given appid.
-pub fn find_entry_from_appid<'a, I>(entries: I, appid: &str) -> Option<&'a DesktopEntry<'a>>
+pub fn find_entry_from_appid<'a, I>(entries: I, appid: &str) -> Option<&'a DesktopEntry>
 where
-    I: IntoIterator<Item = &'a DesktopEntry<'a>>,
+    I: IntoIterator<Item = &'a DesktopEntry>,
 {
     let normalized_appid = appid.to_lowercase();
 


### PR DESCRIPTION
This PR correctly handle escaped chars (\n, \s, ...).
I also removed the lifetime to simplify the implementation and the API. The benchmark showed that it's not really worth to use a lifetime here:

Before this PR
```
bench_borrowed: 11.37ms
bench_owned: 12.01ms
```

After
```
time to parse all .desktop files: 11.17ms
```

That right! it's faster even tho we are not borrowing AND we handle escaped chars. This is because i added an optimization, to not search in the `BTreeMap` in each line.

I also created a new type Group, to write this:

```rs
let group = desktop_entry
            .groups
            .group("Plugin")
            .ok_or(anyhow!("no Plugin group"))?;

let name = group
                .localized_entry("Name", &locales)
                .ok_or(anyhow!("no Name field"))?
                .to_string()