### PR TITLE
Fix panic parsing of value ending in \

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -272,7 +272,7 @@ fn format_value(input: &str) -> Result<String, DecodeError> {
         }
 
         // when there is an \ at the end
-        if input.len() < i + 1 {
+        if input.len() <= i + 1 {
             return Err(DecodeError::InvalidValue);
         }
 


### PR DESCRIPTION
If `input.len() = i + 1`, then `i + 1` isn't a valid index, and this panics.