### PR TITLE
fix: remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,8 @@ categories = [ "os::unix-apis" ]
 keywords = [ "freedesktop", "desktop", "entry" ]
 
 [dependencies]
-dirs = "5"
 gettext-rs = { version = "0.7", features = ["gettext-system"]}
 memchr = "2"
-textdistance = "1"
 strsim = "0.11"
 thiserror = "2"
 xdg = "2"


### PR DESCRIPTION
`dirs` and `textdistance` do not appear to be used in source.  

## Testing 

* Able to compile and test after change