### PR TITLE
feat: add SystemLinyaps PathSource for /var/lib/linglong

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,6 +626,7 @@ pub enum PathSource {
     SystemLocal,
     SystemFlatpak,
     SystemSnap,
+    SystemLinyaps,
     Other(String),
 }
 
@@ -647,6 +648,8 @@ impl PathSource {
             PathSource::SystemFlatpak
         } else if path.starts_with("/var/lib/snapd") {
             PathSource::SystemSnap
+        } else if path.starts_with("/var/lib/linglong") {
+            PathSource::SystemLinyaps
         } else if path.starts_with("/nix/var/nix/profiles/default")
             || path.starts_with("/nix/store")
             || path.starts_with("/run/current-system/sw")


### PR DESCRIPTION
> When an application is installed on the host, the Linyaps package manager will use this link file to link all files in it to the path added by Linyaps to the `$XDG_DATA_DIRS` variable. That is, `/var/lib/linglong/entries/share/`.

https://github.com/OpenAtom-Linyaps/linyaps/blob/499446603edb43689ab26004d6bbdf601bf8c4f0/docs/pages/en/guide/building/linyaps_package_spec.md?plain=1#L754