### PR TITLE
fix: parse space in exec

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -3,7 +3,7 @@
 
 use std::{fs, time::Duration};
 
-use freedesktop_desktop_entry::{DesktopEntry, Iter, default_paths, get_languages_from_env};
+use freedesktop_desktop_entry::{default_paths, get_languages_from_env, DesktopEntry, Iter};
 
 use std::time::Instant;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -161,7 +161,7 @@ impl DesktopEntry {
                     &mut unknown_keys,
                 )?;
             }
-            
+
             if let Some(active_keys) = active_keys.take() {
                 match &mut active_group {
                     Some(active_group) => {
@@ -312,7 +312,11 @@ fn process_line<'a>(
             });
         }
         Line::Entry(key, value) => {
-            let value = format_value(value)?;
+            let value = if key == "Exec" || key == "TryExec" {
+                value.to_string()
+            } else {
+                format_value(value)?
+            };
 
             // if locale
             if key.as_bytes()[key.len() - 1] == b']' {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::DesktopEntry;
+use crate::{decoder::format_value, DesktopEntry};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -84,7 +84,9 @@ impl DesktopEntry {
             let mut args: Vec<String> = Vec::new();
 
             for arg in exec.split_ascii_whitespace() {
-                match ArgOrFieldCode::try_from(arg) {
+                let arg = format_value(arg)
+                    .map_err(|_| ExecError::WrongFormat("cannot format value".into()))?;
+                match ArgOrFieldCode::try_from(arg.as_str()) {
                     Ok(arg) => match arg {
                         ArgOrFieldCode::SingleFileName | ArgOrFieldCode::SingleUrl => {
                             if let Some(arg) = uris.first() {
@@ -186,7 +188,7 @@ mod test {
 
     use std::path::PathBuf;
 
-    use crate::{DesktopEntry, get_languages_from_env};
+    use crate::{get_languages_from_env, DesktopEntry};
 
     use super::ExecError;
 
@@ -209,7 +211,21 @@ mod test {
 
         assert!(matches!(result.unwrap_err(), ExecError::ExecFieldIsEmpty));
     }
+    #[test]
+    fn parse_space() {
+        let path = PathBuf::from("tests_entries/exec/gog_com-Dead_Cells_1.desktop");
+        let locales = get_languages_from_env();
+        let de = DesktopEntry::from_path(path, Some(&locales)).unwrap();
+        let result = de.parse_exec();
 
+        assert_eq!(
+            result.unwrap(),
+            vec![
+                "/home/abc/GOG Games/Dead Cells/start.sh".to_string(),
+                "\"\"".to_string()
+            ]
+        );
+    }
     #[test]
     fn should_exec_simple_command() {
         let path = PathBuf::from("tests_entries/exec/alacritty-simple.desktop");

--- a/tests_entries/exec/gog_com-Dead_Cells_1.desktop
+++ b/tests_entries/exec/gog_com-Dead_Cells_1.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Encoding=UTF-8
+Value=1.0
+Type=Application
+Name=Dead Cells
+GenericName=Dead Cells
+Comment=Dead Cells
+Icon=/home/abc/GOG\sGames/Dead\sCells/support/icon.png
+Exec=/home/abc/GOG\sGames/Dead\sCells/start.sh ""
+Categories=Game;
+Path=/home/abc/GOG\sGames/Dead\sCells
+


### PR DESCRIPTION
Sometimes we have some exec contains space, so this pr is to parse them in the right way