### PR TITLE
fix: add missing path for NixOS PathSource detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,6 +657,7 @@ impl PathSource {
         } else if path.starts_with(data_home.as_path()) {
             PathSource::Local
         } else if path.starts_with("/nix/var/nix/profiles/per-user")
+            || path.starts_with("/etc/profiles/per-user")
             || path.to_string_lossy().contains(".nix")
             || path.starts_with(nix_state.as_path())
         {


### PR DESCRIPTION
When installing user packages via `users.users.<name>.packages` option in NixOS, it places the user profile at `/etc/profiles/per-user/$USER`, see [nixpkgs](https://github.com/NixOS/nixpkgs/blob/812b3986fd1568f7a858f97fcf425ad996ba7d25/nixos/modules/config/users-groups.nix#L1008). Add this path to the LocalNix PathSource detection.