### PR TITLE
feat: recognize /run/system-manager/sw as system Nix path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,6 +650,7 @@ impl PathSource {
         } else if path.starts_with("/nix/var/nix/profiles/default")
             || path.starts_with("/nix/store")
             || path.starts_with("/run/current-system/sw")
+            || path.starts_with("/run/system-manager/sw")
         {
             PathSource::Nix
         } else if path.to_string_lossy().contains("/flatpak/") {


### PR DESCRIPTION
numtide/system-manager (https://github.com/numtide/system-manager) uses /run/system-manager/sw instead of /run/current-system/sw, add it to the Nix path matching.